### PR TITLE
Use HTTPS for Rubygems source, removes deprecation warning.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gemspec
 


### PR DESCRIPTION
Rubygems issues a warning for the old symbol syntax for defining the gemsource. This pull request explicitly specifies the rubygems.org domain and the HTTPS protocol for the gem source.
